### PR TITLE
avoid patching YAML.safe_load for just one case

### DIFF
--- a/lib/models/project.rb
+++ b/lib/models/project.rb
@@ -14,7 +14,7 @@ class Project
   end
 
   def read_yaml
-    YAML.safe_load(File.read(@full_path))
+    SafeYAML.load(File.read(@full_path))
   end
 
   def write_yaml(obj)

--- a/lib/up_for_grabs_tooling.rb
+++ b/lib/up_for_grabs_tooling.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require 'safe_yaml'
+require "safe_yaml/load"
+
 require 'find'
 require 'json_schemer'
 


### PR DESCRIPTION
Currently when you run the tests locally there are warnings about our use of `safe_yaml`:

```
$ bundle exec rake
/usr/local/lib/ruby/gems/2.6.0/gems/safe_yaml-1.0.5/lib/safe_yaml.rb:28: warning: method redefined; discarding old safe_load
/usr/local/Cellar/ruby/2.6.5/lib/ruby/2.6.0/psych.rb:328: warning: previous definition of safe_load was here
/usr/local/lib/ruby/gems/2.6.0/gems/safe_yaml-1.0.5/lib/safe_yaml.rb:52: warning: method redefined; discarding old load_file
/usr/local/Cellar/ruby/2.6.5/lib/ruby/2.6.0/psych.rb:576: warning: previous definition of load_file was here
Run options: --seed 24876

# Running:

........................

Finished in 0.036361s, 660.0479 runs/s, 962.5698 assertions/s.

24 runs, 35 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for Unit Tests to /Users/shiftkey/src/up-for-grabs-gem/coverage. 122 / 124 LOC (98.39%) covered.
```

This is because `safe_yaml` will patch `YAML.safe_load`, and this warns us the first time we run it.

We don't need to do this all this patching for just one case, so I'm going to clean this up so we're using `SafeYAML.load` directly...

Here's what it looks like when running the tests locally:

```
$ bundle exec rake
Run options: --seed 30914

# Running:

........................

Finished in 0.035860s, 669.2694 runs/s, 976.0178 assertions/s.

24 runs, 35 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for Unit Tests to /Users/shiftkey/src/up-for-grabs-gem/coverage. 123 / 125 LOC (98.4%) covered.
```