### PR TITLE
add module for querying the GitHub API to measure activity on the label

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,11 @@ Metrics/LineLength:
     - 'test/**/*.rb'
 
 Metrics/AbcSize:
-  Max: 20
+  Max: 24
 
 Metrics/MethodLength:
-  Max: 25
+  Max: 41
+
+Lint/NestedMethodDefinition:
+  Exclude:
+    - 'lib/queries/github_repository_label_active_check.rb'

--- a/lib/queries/github_repository_label_active_check.rb
+++ b/lib/queries/github_repository_label_active_check.rb
@@ -27,7 +27,7 @@ module GitHubRepositoryLabelActiveCheck
       }
     end
 
-    result = client.query(self.class.RateLimitQuery)
+    result = client.query(RateLimitQuery)
 
     return { rate_limited: true } if result.data.rate_limit.remaining.zero?
 
@@ -40,7 +40,7 @@ module GitHubRepositoryLabelActiveCheck
 
     variables = { owner: owner, name: name, label: label }
 
-    parse(client.query(self.class.IssueCountForLabel, variables: variables))
+    parse(client.query(IssueCountForLabel, variables: variables))
   rescue StandardError => e
     { reason: 'error', error: e }
   end

--- a/lib/queries/github_repository_label_active_check.rb
+++ b/lib/queries/github_repository_label_active_check.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'graphql/client'
-require 'graphql/client/http'
-
 # Check using the GitHub API whether the label in a repository is active
 module GitHubRepositoryLabelActiveCheck
   def self.parse(result)

--- a/lib/queries/github_repository_label_active_check.rb
+++ b/lib/queries/github_repository_label_active_check.rb
@@ -27,7 +27,7 @@ module GitHubRepositoryLabelActiveCheck
       }
     end
 
-    result = client.query(RateLimitQuery)
+    result = client.query(GitHubRepositoryLabelActiveCheck::RateLimitQuery)
 
     return { rate_limited: true } if result.data.rate_limit.remaining.zero?
 
@@ -64,7 +64,7 @@ module GitHubRepositoryLabelActiveCheck
 
     client = GraphQL::Client.new(schema: schema, execute: http)
 
-    self.class.RateLimitQuery = client.parse <<-'GRAPHQL'
+    GitHubRepositoryLabelActiveCheck.const_set :RateLimitQuery, client.parse(<<-'GRAPHQL')
       {
         rateLimit {
           remaining
@@ -72,7 +72,7 @@ module GitHubRepositoryLabelActiveCheck
       }
     GRAPHQL
 
-    self.class.IssueCountForLabel = client.parse <<-'GRAPHQL'
+    GitHubRepositoryLabelActiveCheck.const_set :IssueCountForLabel, client.parse(<<-'GRAPHQL')
       query($owner: String!, $name: String!, $label: String!) {
         repository(owner: $owner, name: $name) {
           label(name: $label) {
@@ -95,8 +95,6 @@ module GitHubRepositoryLabelActiveCheck
         }
       }
     GRAPHQL
-
-    client
   end
 
   private_class_method :client, :create_client

--- a/lib/queries/github_repository_label_active_check.rb
+++ b/lib/queries/github_repository_label_active_check.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'graphql/client'
+require 'graphql/client/http'
+
+# Check using the GitHub API whether the label in a repository is active
+module GitHubRepositoryLabelActiveCheck
+  HTTP = GraphQL::Client::HTTP.new('https://api.github.com/graphql') do
+    def headers(_context)
+      # Optionally set any HTTP headers
+      {
+        "User-Agent": 'up-for-grabs-graphql-label-queries',
+        "Authorization": "bearer #{ENV['GITHUB_TOKEN']}"
+      }
+    end
+  end
+
+  Schema = GraphQL::Client.load_schema(HTTP)
+
+  @client = GraphQL::Client.new(schema: Schema, execute: HTTP)
+
+  RateLimitQuery = @client.parse <<-'GRAPHQL'
+    {
+      rateLimit {
+        remaining
+      }
+    }
+  GRAPHQL
+
+  IssueCountForLabel = @client.parse <<-'GRAPHQL'
+    query($owner: String!, $name: String!, $label: String!) {
+      repository(owner: $owner, name: $name) {
+        label(name: $label) {
+          name
+          url
+          issues(states: OPEN, first: 2, orderBy: {field: UPDATED_AT, direction: DESC}) {
+            totalCount
+            nodes {
+              number
+              updatedAt
+            }
+          }
+        }
+      }
+      rateLimit {
+        limit
+        cost
+        remaining
+        resetAt
+      }
+    }
+  GRAPHQL
+
+  def self.parse(result)
+    repository = result.data.repository
+
+    # we should be checking for repository existence before this, but flag it anyway
+    return { reason: 'repository-missing' } if repository.nil?
+
+    return { reason: 'missing' } if repository.label.nil?
+
+    label = repository.label
+    count = label.issues.total_count
+    last_updated = label.issues.nodes[0].updated_at
+
+    { reason: 'found', name: label.name, url: label.url, count: count, last_updated: last_updated }
+  end
+
+  def self.run(project)
+    owner_and_repo = project.github_owner_name_pair
+
+    unless owner_and_repo
+      return {
+        reason: 'error',
+        error: StandardError.new("Project #{project.relative_path} is not using GitHub")
+      }
+    end
+
+    result = @client.query(RateLimitQuery)
+
+    return { rate_limited: true } if result.data.rate_limit.remaining.zero?
+
+    items = owner_and_repo.split('/')
+    owner = items[0]
+    name = items[1]
+
+    yaml = project.read_yaml
+    label = yaml['upforgrabs']['name']
+
+    variables = { owner: owner, name: name, label: label }
+
+    parse(@client.query(IssueCountForLabel, variables: variables))
+  rescue StandardError => e
+    { reason: 'error', error: e }
+  end
+end

--- a/lib/queries/github_repository_label_active_check.rb
+++ b/lib/queries/github_repository_label_active_check.rb
@@ -12,7 +12,11 @@ module GitHubRepositoryLabelActiveCheck
 
     label = repository.label
     count = label.issues.total_count
-    last_updated = label.issues.nodes[0].updated_at
+    if count > 0
+      last_updated = label.issues.nodes[0].updated_at
+    else
+      last_updated = nil
+    end
 
     { reason: 'found', name: label.name, url: label.url, count: count, last_updated: last_updated }
   end
@@ -78,7 +82,7 @@ module GitHubRepositoryLabelActiveCheck
           label(name: $label) {
             name
             url
-            issues(states: OPEN, first: 2, orderBy: {field: UPDATED_AT, direction: DESC}) {
+            issues(states: OPEN, first: 1, orderBy: {field: UPDATED_AT, direction: DESC}) {
               totalCount
               nodes {
                 number

--- a/lib/queries/github_repository_label_active_check.rb
+++ b/lib/queries/github_repository_label_active_check.rb
@@ -95,6 +95,8 @@ module GitHubRepositoryLabelActiveCheck
         }
       }
     GRAPHQL
+
+    client
   end
 
   private_class_method :client, :create_client

--- a/lib/queries/github_repository_label_active_check.rb
+++ b/lib/queries/github_repository_label_active_check.rb
@@ -12,11 +12,7 @@ module GitHubRepositoryLabelActiveCheck
 
     label = repository.label
     count = label.issues.total_count
-    if count > 0
-      last_updated = label.issues.nodes[0].updated_at
-    else
-      last_updated = nil
-    end
+    last_updated = (label.issues.nodes[0].updated_at if count.positive?)
 
     { reason: 'found', name: label.name, url: label.url, count: count, last_updated: last_updated }
   end

--- a/lib/up_for_grabs_tooling.rb
+++ b/lib/up_for_grabs_tooling.rb
@@ -5,8 +5,7 @@ require 'safe_yaml/load'
 require 'find'
 require 'json_schemer'
 
-require 'graphql/client'
-require 'graphql/client/http'
+require 'graphql'
 
 require 'models/project'
 

--- a/lib/up_for_grabs_tooling.rb
+++ b/lib/up_for_grabs_tooling.rb
@@ -12,3 +12,4 @@ require 'validators/directory'
 require 'validators/project'
 
 require 'queries/github_repository_active_check'
+require 'queries/github_repository_label_active_check'

--- a/lib/up_for_grabs_tooling.rb
+++ b/lib/up_for_grabs_tooling.rb
@@ -5,6 +5,9 @@ require 'safe_yaml/load'
 require 'find'
 require 'json_schemer'
 
+require 'graphql/client'
+require 'graphql/client/http'
+
 require 'models/project'
 
 require 'validators/data_files'

--- a/lib/up_for_grabs_tooling.rb
+++ b/lib/up_for_grabs_tooling.rb
@@ -5,7 +5,8 @@ require 'safe_yaml/load'
 require 'find'
 require 'json_schemer'
 
-require 'graphql'
+require 'graphql/client'
+require 'graphql/client/http'
 
 require 'models/project'
 


### PR DESCRIPTION
This extracts the important parts of updating project stats, and uses a more important check for activity - the last time any issue has been updated. I believe that's a more accurate proxy for the relevant activity on a project than the repository's updated at timestamp.

- [x] implement as new module
- [x] address CI issue with new module