### PR TITLE
make schemer optional to simplify internals

### DIFF
--- a/lib/validators/data_files.rb
+++ b/lib/validators/data_files.rb
@@ -4,13 +4,19 @@ require_relative 'project'
 
 # Validate the data files
 class DataFilesValidator
-  def self.validate(root, schemer)
+  def self.validate(root, schemer = nil)
     projects = Dir["#{root}/_data/projects/*.yml"].map do |f|
       relative_path = Pathname.new(f).relative_path_from(root).to_s
       Project.new(relative_path, f)
     end
 
     projects_with_errors = {}
+
+    if schemer.nil?
+      root = File.dirname(File.dirname(__dir__))
+      schema = Pathname.new("#{root}/schema.json")
+      schemer = JSONSchemer.schema(schema)
+    end
 
     projects.each do |p|
       validation_errors = ProjectValidator.validate(p, schemer)

--- a/test/validators/data_files_test.rb
+++ b/test/validators/data_files_test.rb
@@ -4,20 +4,18 @@ require_relative '../test_helper'
 
 class DataFilesValidatorTests < Minitest::Test
   def test_valid_directory
-    schemer = setup_schemer
     path = get_directory('valid_project_files')
 
-    result = DataFilesValidator.validate(path, schemer)
+    result = DataFilesValidator.validate(path)
 
     assert_equal 3, result[:count]
     assert result[:errors].empty?
   end
 
   def test_file_has_error
-    schemer = setup_schemer
     path = get_directory('one_file_with_error')
 
-    result = DataFilesValidator.validate(path, schemer)
+    result = DataFilesValidator.validate(path)
 
     assert_equal 2, result[:count]
     assert_equal 1, result[:errors].length
@@ -25,12 +23,6 @@ class DataFilesValidatorTests < Minitest::Test
     errors = result[:errors]['_data/projects/error_site_link_url.yml']
     assert_equal 1, errors.length
     assert_equal errors[0], "Field '/site' expects a URL but instead found 'foo'. Please check and update this value."
-  end
-
-  def setup_schemer
-    root = File.dirname(File.dirname(__dir__))
-    schema = Pathname.new("#{root}/schema.json")
-    JSONSchemer.schema(schema)
   end
 
   def get_directory(name)

--- a/up_for_grabs_tooling.gemspec
+++ b/up_for_grabs_tooling.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'up_for_grabs_tooling'
-  s.version     = '0.0.3'
+  s.version     = '0.0.4'
   s.licenses    = ['MIT']
   s.summary     = "Tooling for Up-For-Grabs infrastructure"
   s.description = "This gem is used to simplify the heavy-lifting that infrastructure scripts for Up-For-Grabs uses. As it's very specific to the Up-For-Grabs project, you don't need to use this yourself."


### PR DESCRIPTION
We should favour the `schema.json` in this repository if one isn't provided by the caller.

Eventually I'd like to keep this internal to the tooling, but for now this works fine as an incremental change.