### PR TITLE
add bundle vendor config

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,1 @@
+BUNDLE_PATH: ./vendor/bundle

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.gem
 coverage/
+vendor/


### PR DESCRIPTION
This should help with some local development issues if you want to work without `sudo`-ing often:

```
$ bundle install
Using rake 13.0.1
Following files may not be writable, so sudo is needed:
  /usr/local/bin
  /var/lib/gems/2.5.0
  /var/lib/gems/2.5.0/build_info
  /var/lib/gems/2.5.0/cache
  /var/lib/gems/2.5.0/doc
  /var/lib/gems/2.5.0/extensions
  /var/lib/gems/2.5.0/gems
  /var/lib/gems/2.5.0/specifications
Using concurrent-ruby 1.1.5
Using i18n 1.7.0
Using minitest 5.14.0
Using thread_safe 0.3.6
Using tzinfo 1.2.5
Using zeitwerk 2.2.2
Using activesupport 6.0.1
Using public_suffix 4.0.3
Using addressable 2.7.0
Using ast 2.4.0
...
```