### PR TITLE
update rubocop config to address warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,16 +4,14 @@ AllCops:
     - 'test/**/*.rb'
     - 'Rakefile'
 
-Metrics/CyclomaticComplexity:
-  Max: 8
-
-Metrics/PerceivedComplexity:
-  Max: 9
-
 Layout/LineLength:
   Exclude:
     - 'lib/**/*.rb'
     - 'test/**/*.rb'
+
+Lint/NestedMethodDefinition:
+  Exclude:
+    - 'lib/queries/github_repository_label_active_check.rb'
 
 Lint/RaiseException:
   Enabled: true
@@ -24,12 +22,14 @@ Lint/StructNewOverride:
 Metrics/AbcSize:
   Max: 24
 
+Metrics/CyclomaticComplexity:
+  Max: 8
+
 Metrics/MethodLength:
   Max: 41
 
-Lint/NestedMethodDefinition:
-  Exclude:
-    - 'lib/queries/github_repository_label_active_check.rb'
+Metrics/PerceivedComplexity:
+  Max: 9
 
 Style/HashEachMethods:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,10 +10,16 @@ Metrics/CyclomaticComplexity:
 Metrics/PerceivedComplexity:
   Max: 9
 
-Metrics/LineLength:
+Layout/LineLength:
   Exclude:
     - 'lib/**/*.rb'
     - 'test/**/*.rb'
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
 
 Metrics/AbcSize:
   Max: 24
@@ -24,3 +30,12 @@ Metrics/MethodLength:
 Lint/NestedMethodDefinition:
   Exclude:
     - 'lib/queries/github_repository_label_active_check.rb'
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true


### PR DESCRIPTION
```
 .rubocop.yml: Metrics/LineLength has the wrong namespace - should be Layout
The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file:
 - Lint/RaiseException (0.81)
 - Lint/StructNewOverride (0.81)
 - Style/HashEachMethods (0.80)
 - Style/HashTransformKeys (0.80)
 - Style/HashTransformValues (0.80)
For more information: https://docs.rubocop.org/en/latest/versioning/
Inspecting 16 files
................

16 files inspected, no offenses detected
```