### PR TITLE
extract module for pull request validation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,7 @@ Metrics/AbcSize:
 Metrics/ClassLength:
   Exclude:
     - 'lib/validators/pull_request.rb'
+    - 'test/**/*.rb'
 
 Metrics/CyclomaticComplexity:
   Max: 8

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,10 @@ Lint/StructNewOverride:
 Metrics/AbcSize:
   Enabled: false
 
+Metrics/ClassLength:
+  Exclude:
+    - 'lib/validators/pull_request.rb'
+
 Metrics/CyclomaticComplexity:
   Max: 8
 
@@ -31,6 +35,8 @@ Metrics/MethodLength:
 
 Metrics/PerceivedComplexity:
   Max: 9
+  Exclude:
+    - 'lib/validators/pull_request.rb'
 
 Style/HashEachMethods:
   Enabled: true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "files.exclude": {
-    "**/vendor": true
+    "**/vendor": true,
+    "**/coverage": true
   }
 }

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 
 gem 'minitest', group: :test
 gem 'simplecov', require: false, group: :test
+gem 'mocha', group: :test
 
 gem 'rubocop', require: false
 gem 'rake', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,7 @@ GEM
       regexp_parser (~> 1.5)
       uri_template (~> 0.7)
     minitest (5.14.0)
+    mocha (1.11.2)
     multipart-post (2.1.1)
     octokit (4.18.0)
       faraday (>= 0.9)
@@ -80,6 +81,7 @@ PLATFORMS
 
 DEPENDENCIES
   minitest
+  mocha
   rake
   rubocop
   simplecov

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,4 +88,4 @@ DEPENDENCIES
   up_for_grabs_tooling!
 
 BUNDLED WITH
-   2.1.4
+   2.0.2

--- a/lib/up_for_grabs_tooling.rb
+++ b/lib/up_for_grabs_tooling.rb
@@ -16,6 +16,7 @@ require 'validators/directory'
 require 'validators/schema'
 require 'validators/tags'
 require 'validators/command_line'
+require 'validators/pull_request'
 
 require 'queries/github_repository_active_check'
 require 'queries/github_repository_label_active_check'

--- a/lib/validators/pull_request.rb
+++ b/lib/validators/pull_request.rb
@@ -36,7 +36,7 @@ class PullRequestValidator
         path = result[:project].relative_path
 
         if result[:kind] == 'valid'
-          "#### `#{path}` :white_check_mark: \nNo problems found, everything should be good to merge!"
+          "#### `#{path}` :white_check_mark:\nNo problems found, everything should be good to merge!"
         elsif result[:kind] == 'validation'
           message = result[:validation_errors].map { |e| "> - #{e}" }.join "\n"
           "#### `#{path}` :x:\nI had some troubles parsing the project file, or there were fields that are missing that I need.\n\nHere's the details:\n#{message}"

--- a/lib/validators/pull_request.rb
+++ b/lib/validators/pull_request.rb
@@ -45,7 +45,8 @@ class PullRequestValidator
           "Everything should be good to merge!"
         ]
       else
-        messages = [ "THINGS" ]
+        messages = [ "#### **#{valid_projects.count}** projects without issues :white_check_mark:" ]
+        messages << projects_with_errors.map { |result| get_validation_message(result) }
       end
     else
       messages = projects.map { |p| review_project(p) }.map { |result| get_validation_message(result) }

--- a/lib/validators/pull_request.rb
+++ b/lib/validators/pull_request.rb
@@ -16,7 +16,7 @@ class PullRequestValidator
 
   UPDATE_HEADER = 'Checking the latest changes to the pull request...'
 
-  def self.validate(dir, files, initial_message: true)
+  def self.generate_comment(dir, files, initial_message: true)
     projects = files.map do |f|
       full_path = File.join(dir, f)
 

--- a/lib/validators/pull_request.rb
+++ b/lib/validators/pull_request.rb
@@ -14,7 +14,7 @@ class PullRequestValidator
   " I noticed this PR added or modififed the data files under `_data/projects/` so I had a look at what's changed.\n\n" \
   "As you make changes to this pull request, I'll re-run these checks."
 
-  UPDATE_HEADER = 'Checking the latest changes to the pull request:'
+  UPDATE_HEADER = 'Checking the latest changes to the pull request...'
 
   def self.validate(dir, files, initial_message: true)
     projects = files.map do |f|

--- a/lib/validators/pull_request.rb
+++ b/lib/validators/pull_request.rb
@@ -124,20 +124,20 @@ class PullRequestValidator
       return nil
     end
 
-    label = find_label(project)
-
     if result[:reason] == 'repository-missing'
       return "I couldn't find the GitHub repository '#{project.github_owner_name_pair}' that was used in the `upforgrabs.link` value." \
             " Please confirm this is correct or hasn't been mis-typed."
     end
 
+    yaml = project.read_yaml
+
     if result[:reason] == 'missing'
+      label = yaml['upforgrabs']['name']
       return "The `upforgrabs.name` value '#{label}' isn't in use on the project in GitHub." \
             ' This might just be a mistake due because of copy-pasting the reference template or be mis-typed.' \
             " Please check the list of labels at https://github.com/#{project.github_owner_name_pair}/labels and update the project file to use the correct label."
     end
 
-    yaml = project.read_yaml
     link = yaml['upforgrabs']['link']
     url = result[:url]
 
@@ -150,13 +150,7 @@ class PullRequestValidator
     nil
   end
 
-  def self.find_label(project)
-    yaml = project.read_yaml
-    yaml['upforgrabs']['name']
-  end
-
   private_class_method :review_project
   private_class_method :repository_check
   private_class_method :label_check
-  private_class_method :find_label
 end

--- a/lib/validators/pull_request.rb
+++ b/lib/validators/pull_request.rb
@@ -49,7 +49,7 @@ class PullRequestValidator
         messages << projects_with_errors.map { |result| get_validation_message(result) }
       end
     else
-      messages = projects.map { |p| review_project(p) }.map { |result| get_validation_message(result) }
+      messages = projects.map { |p| review_project(p) }.map { |r| get_validation_message(r) }
     end
 
     markdown_body + messages.join("\n\n")

--- a/lib/validators/pull_request.rb
+++ b/lib/validators/pull_request.rb
@@ -15,15 +15,10 @@ class PullRequestValidator
   "As you make changes to this pull request, I'll re-run these checks.\n\n"
 
   def self.validate(dir, files, _initial_message = false, _schemer = nil)
-
     projects = files.map do |f|
       full_path = File.join(dir, f)
 
-      if File.exist?(full_path)
-        Project.new(f, full_path)
-      else
-        nil
-      end
+      Project.new(f, full_path) if File.exist?(full_path)
     end
 
     markdown_body = "#{PREAMBLE_HEADER}\n\n" + GREETING_HEADER

--- a/lib/validators/pull_request.rb
+++ b/lib/validators/pull_request.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+# This class validates the changed files in a pull request, and performs
+# several checks during this process:
+#
+#  - schema validation for all current projects
+#  - tag validation
+#  - directory structure validation
+#
+class PullRequestValidator
+  PREAMBLE_HEADER = '<!-- PULL REQUEST ANALYZER GITHUB ACTION -->'
+
+  GREETING_HEADER = ":wave: I'm a robot checking the state of this pull request to save the human reveiwers time." \
+  " I noticed this PR added or modififed the data files under `_data/projects/` so I had a look at what's changed.\n\n" \
+  "As you make changes to this pull request, I'll re-run these checks.\n\n"
+
+  def self.validate(dir, files, _initial_message = false, _schemer = nil)
+
+    projects = files.map do |f|
+      full_path = File.join(dir, f)
+
+      if File.exist?(full_path)
+        Project.new(f, full_path)
+      else
+        nil
+      end
+    end
+
+    markdown_body = "#{PREAMBLE_HEADER}\n\n" + GREETING_HEADER
+
+    messages = projects.compact.map { |p| review_project(p) }.map do |result|
+      path = result[:project].relative_path
+
+      if result[:kind] == 'valid'
+        "#### `#{path}` :white_check_mark: \nNo problems found, everything should be good to merge!"
+      elsif result[:kind] == 'validation'
+        message = result[:validation_errors].map { |e| "> - #{e}" }.join "\n"
+        "#### `#{path}` :x:\nI had some troubles parsing the project file, or there were fields that are missing that I need.\n\nHere's the details:\n#{message}"
+      elsif result[:kind] == 'tags'
+        message = result[:tags_errors].map { |e| "> - #{e}" }.join "\n"
+        "#### `#{path}` :x:\nI have some suggestions about the tags used in the project:\n\n#{message}"
+      elsif result[:kind] == 'repository' || result[:kind] == 'label'
+        "#### `#{path}` :x:\n#{result[:message]}"
+      else
+        "#### `#{path}` :question:\nI got a result of type '#{result[:kind]}' that I don't know how to handle. I need to mention @shiftkey here as he might be able to fix it."
+      end
+    end
+
+    markdown_body + messages.join("\n\n")
+  end
+
+  private
+
+  def self.review_project(project)
+    validation_errors = SchemaValidator.validate(project)
+
+    if validation_errors.any?
+      return { project: project, kind: 'validation', validation_errors: validation_errors }
+    end
+
+    tags_errors = TagsValidator.validate(project)
+
+    if tags_errors.any?
+      return { project: project, kind: 'tags', tags_errors: tags_errors }
+    end
+
+    return { project: project, kind: 'valid' } unless project.github_project?
+
+    repository_error = repository_check(project)
+
+    unless repository_error.nil?
+      return { project: project, kind: 'repository', message: repository_error }
+    end
+
+    label_error = label_check(project)
+
+    unless label_error.nil?
+      return { project: project, kind: 'label', message: label_error }
+    end
+
+    { project: project, kind: 'valid' }
+  end
+
+  def self.repository_check(project)
+    # TODO: this looks for GITHUB_TOKEN underneath - it should not be hard-coded like this
+    # TODO: cleanup the GITHUB_TOKEN setting once this is decoupled from the environment variable
+    result = GitHubRepositoryActiveCheck.run(project)
+
+    if result[:rate_limited]
+      logger.info 'This script is currently rate-limited by the GitHub API'
+      logger.info 'Marking as inconclusive to indicate that no further work will be done here'
+      return nil
+    end
+
+    if result[:reason] == 'archived'
+      return "The GitHub repository '#{project.github_owner_name_pair}' has been marked as archived, which suggests it is not active."
+    end
+
+    if result[:reason] == 'missing'
+      return "The GitHub repository '#{project.github_owner_name_pair}' cannot be found. Please confirm the location of the project."
+    end
+
+    if result[:reason] == 'redirect'
+      return "The GitHub repository '#{result[:old_location]}' is now at '#{result[:location]}'. Please update this project before this is merged."
+    end
+
+    if result[:reason] == 'error'
+      return "The GitHub repository '#{project.github_owner_name_pair}' could not be confirmed. Error details: #{result[:error]}"
+    end
+
+    nil
+  end
+
+  def label_check(project)
+    result = GitHubRepositoryLabelActiveCheck.run(project)
+
+    if result[:rate_limited]
+      logger.info 'This script is currently rate-limited by the GitHub API'
+      logger.info 'Marking as inconclusive to indicate that no further work will be done here'
+      return nil
+    end
+
+    label = find_label(project)
+
+    if result[:reason] == 'repository-missing'
+      return "I couldn't find the GitHub repository '#{project.github_owner_name_pair}' that was used in the `upforgrabs.link` value." \
+            " Please confirm this is correct or hasn't been mis-typed."
+    end
+
+    if result[:reason] == 'missing'
+      return "The `upforgrabs.name` value '#{label}' isn't in use on the project in GitHub." \
+            ' This might just be a mistake due because of copy-pasting the reference template or be mis-typed.' \
+            " Please check the list of labels at https://github.com/#{project.github_owner_name_pair}/labels and update the project file to use the correct label."
+    end
+
+    yaml = project.read_yaml
+    link = yaml['upforgrabs']['link']
+    url = result[:url]
+
+    link_needs_rewriting = link != url && link.include?('/labels/')
+
+    if link_needs_rewriting
+      return "The label '#{label}' for GitHub repository '#{project.github_owner_name_pair}' does not match the specified `upforgrabs.link` value. Please update it to `#{url}`."
+    end
+
+    nil
+  end
+end

--- a/lib/validators/pull_request.rb
+++ b/lib/validators/pull_request.rb
@@ -44,7 +44,9 @@ class PullRequestValidator
     markdown_body + messages.join("\n\n")
   end
 
-  private
+  private_class_method :review_project
+  private_class_method :repository_check
+  private_class_method :label_check
 
   def self.review_project(project)
     validation_errors = SchemaValidator.validate(project)

--- a/lib/validators/pull_request.rb
+++ b/lib/validators/pull_request.rb
@@ -12,16 +12,18 @@ class PullRequestValidator
 
   GREETING_HEADER = ":wave: I'm a robot checking the state of this pull request to save the human reveiwers time." \
   " I noticed this PR added or modififed the data files under `_data/projects/` so I had a look at what's changed.\n\n" \
-  "As you make changes to this pull request, I'll re-run these checks.\n\n"
+  "As you make changes to this pull request, I'll re-run these checks."
 
-  def self.validate(dir, files, _initial_message = false, _schemer = nil)
+  UPDATE_HEADER = 'Checking the latest changes to the pull request:'
+
+  def self.validate(dir, files, initial_message: true)
     projects = files.map do |f|
       full_path = File.join(dir, f)
 
       Project.new(f, full_path) if File.exist?(full_path)
     end
 
-    markdown_body = "#{PREAMBLE_HEADER}\n\n" + GREETING_HEADER
+    markdown_body = "#{PREAMBLE_HEADER}\n\n" + get_header(initial_message) + "\n\n"
 
     projects_without_valid_extensions = projects.reject { |p| File.extname(p.relative_path) == '.yml' }
 
@@ -53,6 +55,14 @@ class PullRequestValidator
     end
 
     markdown_body + messages.join("\n\n")
+  end
+
+  def self.get_header(initial_message)
+    if initial_message
+      GREETING_HEADER
+    else
+      UPDATE_HEADER
+    end
   end
 
   def self.review_project(project)

--- a/lib/validators/pull_request.rb
+++ b/lib/validators/pull_request.rb
@@ -156,9 +156,9 @@ class PullRequestValidator
     end
 
     yaml = project.read_yaml
+    label = yaml['upforgrabs']['name']
 
     if result[:reason] == 'missing'
-      label = yaml['upforgrabs']['name']
       return "The `upforgrabs.name` value '#{label}' isn't in use on the project in GitHub." \
             ' This might just be a mistake due because of copy-pasting the reference template or be mis-typed.' \
             " Please check the list of labels at https://github.com/#{project.github_owner_name_pair}/labels and update the project file to use the correct label."

--- a/lib/validators/pull_request.rb
+++ b/lib/validators/pull_request.rb
@@ -23,14 +23,14 @@ class PullRequestValidator
 
     markdown_body = "#{PREAMBLE_HEADER}\n\n" + GREETING_HEADER
 
-    projects_without_valid_extensions = projects.select { |p| File.extname(p.relative_path) != ".yml" }
+    projects_without_valid_extensions = projects.reject { |p| File.extname(p.relative_path) == '.yml' }
 
     if projects_without_valid_extensions.any?
-      messages = [ "#### Unexpected files found in project directory" ]
+      messages = ['#### Unexpected files found in project directory']
       projects_without_valid_extensions.each do |p|
         messages << " - `#{p.relative_path}`"
       end
-      messages << "All files under `_data/projects/` must end with `.yml` to be listed on the site"
+      messages << 'All files under `_data/projects/` must end with `.yml` to be listed on the site'
     else
       messages = projects.compact.map { |p| review_project(p) }.map do |result|
         path = result[:project].relative_path

--- a/lib/validators/pull_request.rb
+++ b/lib/validators/pull_request.rb
@@ -37,15 +37,15 @@ class PullRequestValidator
       messages << 'All files under `_data/projects/` must end with `.yml` to be listed on the site'
     elsif projects.count > 2
       results = projects.map { |p| review_project(p) }
-      valid_projects, projects_with_errors = results.partition { |r| r[:kind] == "valid" }
+      valid_projects, projects_with_errors = results.partition { |r| r[:kind] == 'valid' }
 
       if projects_with_errors.empty?
         messages = [
           "#### **#{valid_projects.count}** projects without issues :white_check_mark:",
-          "Everything should be good to merge!"
+          'Everything should be good to merge!'
         ]
       else
-        messages = [ "#### **#{valid_projects.count}** projects without issues :white_check_mark:" ]
+        messages = ["#### **#{valid_projects.count}** projects without issues :white_check_mark:"]
         messages << projects_with_errors.map { |result| get_validation_message(result) }
       end
     else

--- a/lib/validators/pull_request.rb
+++ b/lib/validators/pull_request.rb
@@ -150,7 +150,13 @@ class PullRequestValidator
     nil
   end
 
+  def self.find_label(project)
+    yaml = project.read_yaml
+    yaml['upforgrabs']['name']
+  end
+
   private_class_method :review_project
   private_class_method :repository_check
   private_class_method :label_check
+  private_class_method :find_label
 end

--- a/lib/validators/pull_request.rb
+++ b/lib/validators/pull_request.rb
@@ -44,10 +44,6 @@ class PullRequestValidator
     markdown_body + messages.join("\n\n")
   end
 
-  private_class_method :review_project
-  private_class_method :repository_check
-  private_class_method :label_check
-
   def self.review_project(project)
     validation_errors = SchemaValidator.validate(project)
 
@@ -108,7 +104,7 @@ class PullRequestValidator
     nil
   end
 
-  def label_check(project)
+  def self.label_check(project)
     result = GitHubRepositoryLabelActiveCheck.run(project)
 
     if result[:rate_limited]
@@ -142,4 +138,8 @@ class PullRequestValidator
 
     nil
   end
+
+  private_class_method :review_project
+  private_class_method :repository_check
+  private_class_method :label_check
 end

--- a/lib/validators/tags.rb
+++ b/lib/validators/tags.rb
@@ -60,7 +60,7 @@ class TagsValidator
     tags.each do |tag|
       preferred_tag = PREFERENCES[tag]
 
-      errors << "Rename tag '#{tag}' to be'#{preferred_tag}'" if preferred_tag
+      errors << "Rename tag '#{tag}' to be '#{preferred_tag}'" if preferred_tag
     end
 
     errors

--- a/test/fixtures/pull_request/github-repository-archived-result.md
+++ b/test/fixtures/pull_request/github-repository-archived-result.md
@@ -1,0 +1,8 @@
+<!-- PULL REQUEST ANALYZER GITHUB ACTION -->
+
+:wave: I'm a robot checking the state of this pull request to save the human reveiwers time. I noticed this PR added or modififed the data files under `_data/projects/` so I had a look at what's changed.
+
+As you make changes to this pull request, I'll re-run these checks.
+
+#### `_data/projects/project.yml` :x:
+The GitHub repository 'owner/repo' has been marked as archived, which suggests it is not active.

--- a/test/fixtures/pull_request/github-repository-archived/_data/projects/project.yml
+++ b/test/fixtures/pull_request/github-repository-archived/_data/projects/project.yml
@@ -1,0 +1,12 @@
+---
+name: Some Project
+desc: This is very much a project
+site: https://github.com/owner/repo
+tags:
+- tag
+- tag2
+- tag3
+- tag4
+upforgrabs:
+  name: label
+  link: https://github.com/owner/repo/labels/label

--- a/test/fixtures/pull_request/missing-extension-result.md
+++ b/test/fixtures/pull_request/missing-extension-result.md
@@ -1,0 +1,11 @@
+<!-- PULL REQUEST ANALYZER GITHUB ACTION -->
+
+:wave: I'm a robot checking the state of this pull request to save the human reveiwers time. I noticed this PR added or modififed the data files under `_data/projects/` so I had a look at what's changed.
+
+As you make changes to this pull request, I'll re-run these checks.
+
+#### Unexpected files found in project directory
+
+ - `_data/projects/project`
+
+All files under `_data/projects/` must end with `.yml` to be listed on the site

--- a/test/fixtures/pull_request/missing-extension/_data/projects/project
+++ b/test/fixtures/pull_request/missing-extension/_data/projects/project
@@ -1,0 +1,12 @@
+---
+name: Up-For-Grabs.net
+desc: This site!
+site: https://github.com/up-for-grabs/up-for-grabs.net
+tags:
+- oss
+- web
+- jekyll
+- javascript
+upforgrabs:
+  name: up-for-grabs
+  link: https://github.com/up-for-grabs/up-for-grabs.net/labels/up-for-grabs

--- a/test/fixtures/pull_request/one-file-label-error-result.md
+++ b/test/fixtures/pull_request/one-file-label-error-result.md
@@ -1,0 +1,8 @@
+<!-- PULL REQUEST ANALYZER GITHUB ACTION -->
+
+:wave: I'm a robot checking the state of this pull request to save the human reveiwers time. I noticed this PR added or modififed the data files under `_data/projects/` so I had a look at what's changed.
+
+As you make changes to this pull request, I'll re-run these checks.
+
+#### `_data/projects/project.yml` :x:
+The label 'label' for GitHub repository 'owner/repo' does not match the specified `upforgrabs.link` value. Please update it to `https://github.com/owner/redirected-repo/labels/label`.

--- a/test/fixtures/pull_request/one-file-label-error/_data/projects/project.yml
+++ b/test/fixtures/pull_request/one-file-label-error/_data/projects/project.yml
@@ -1,0 +1,12 @@
+---
+name: Some Project
+desc: This is very much a project
+site: https://github.com/owner/repo
+tags:
+- tag
+- tag2
+- tag3
+- tag4
+upforgrabs:
+  name: label
+  link: https://github.com/owner/repo/labels/label

--- a/test/fixtures/pull_request/one-file-no-preamble-result.md
+++ b/test/fixtures/pull_request/one-file-no-preamble-result.md
@@ -1,0 +1,6 @@
+<!-- PULL REQUEST ANALYZER GITHUB ACTION -->
+
+Checking the latest changes to the pull request:
+
+#### `_data/projects/project.yml` :white_check_mark:
+No problems found, everything should be good to merge!

--- a/test/fixtures/pull_request/one-file-no-preamble-result.md
+++ b/test/fixtures/pull_request/one-file-no-preamble-result.md
@@ -1,6 +1,6 @@
 <!-- PULL REQUEST ANALYZER GITHUB ACTION -->
 
-Checking the latest changes to the pull request:
+Checking the latest changes to the pull request...
 
 #### `_data/projects/project.yml` :white_check_mark:
 No problems found, everything should be good to merge!

--- a/test/fixtures/pull_request/one-file-result.md
+++ b/test/fixtures/pull_request/one-file-result.md
@@ -1,0 +1,8 @@
+<!-- PULL REQUEST ANALYZER GITHUB ACTION -->
+
+:wave: I'm a robot checking the state of this pull request to save the human reveiwers time. I noticed this PR added or modififed the data files under `_data/projects/` so I had a look at what's changed.
+
+As you make changes to this pull request, I'll re-run these checks.
+
+#### `_data/projects/project.yml` :white_check_mark:
+No problems found, everything should be good to merge!

--- a/test/fixtures/pull_request/one-file/_data/projects/project.yml
+++ b/test/fixtures/pull_request/one-file/_data/projects/project.yml
@@ -1,0 +1,12 @@
+---
+name: Up-For-Grabs.net
+desc: This site!
+site: https://github.com/up-for-grabs/up-for-grabs.net
+tags:
+- oss
+- web
+- jekyll
+- javascript
+upforgrabs:
+  name: up-for-grabs
+  link: https://github.com/up-for-grabs/up-for-grabs.net/labels/up-for-grabs

--- a/test/fixtures/pull_request/schema-validation-result.md
+++ b/test/fixtures/pull_request/schema-validation-result.md
@@ -1,0 +1,11 @@
+<!-- PULL REQUEST ANALYZER GITHUB ACTION -->
+
+:wave: I'm a robot checking the state of this pull request to save the human reveiwers time. I noticed this PR added or modififed the data files under `_data/projects/` so I had a look at what's changed.
+
+As you make changes to this pull request, I'll re-run these checks.
+
+#### `_data/projects/error_site_link_url.yml` :x:
+I had some troubles parsing the project file, or there were fields that are missing that I need.
+
+Here's the details:
+> - Field '/site' expects a URL but instead found 'foo'. Please check and update this value.

--- a/test/fixtures/pull_request/schema-validation/_data/projects/error_site_link_url.yml
+++ b/test/fixtures/pull_request/schema-validation/_data/projects/error_site_link_url.yml
@@ -1,0 +1,9 @@
+---
+name: Up-For-Grabs.net
+desc: This site!
+site: foo
+tags:
+- web
+upforgrabs:
+  name: up-for-grabs
+  link: https://github.com/up-for-grabs/up-for-grabs.net/labels/up-for-grabs

--- a/test/fixtures/pull_request/tags-validation-result.md
+++ b/test/fixtures/pull_request/tags-validation-result.md
@@ -1,0 +1,12 @@
+<!-- PULL REQUEST ANALYZER GITHUB ACTION -->
+
+:wave: I'm a robot checking the state of this pull request to save the human reveiwers time. I noticed this PR added or modififed the data files under `_data/projects/` so I had a look at what's changed.
+
+As you make changes to this pull request, I'll re-run these checks.
+
+#### `_data/projects/project.yml` :x:
+I have some suggestions about the tags used in the project:
+
+> - Rename tag 'aspnet' to be 'asp.net'
+> - Rename tag 'dotnet' to be '.net'
+> - Rename tag 'nodejs' to be 'node.js'

--- a/test/fixtures/pull_request/tags-validation/_data/projects/project.yml
+++ b/test/fixtures/pull_request/tags-validation/_data/projects/project.yml
@@ -1,0 +1,11 @@
+---
+name: Up-For-Grabs.net
+desc: This site!
+site: https://github.com/up-for-grabs/up-for-grabs.net/
+tags:
+- aspnet
+- dotnet
+- nodejs
+upforgrabs:
+  name: up-for-grabs
+  link: https://github.com/up-for-grabs/up-for-grabs.net/labels/up-for-grabs

--- a/test/fixtures/pull_request/three-files-one-error-result.md
+++ b/test/fixtures/pull_request/three-files-one-error-result.md
@@ -1,0 +1,13 @@
+<!-- PULL REQUEST ANALYZER GITHUB ACTION -->
+
+:wave: I'm a robot checking the state of this pull request to save the human reveiwers time. I noticed this PR added or modififed the data files under `_data/projects/` so I had a look at what's changed.
+
+As you make changes to this pull request, I'll re-run these checks.
+
+#### **2** projects without issues :white_check_mark:
+
+#### `_data/projects/third.yml` :x:
+I had some troubles parsing the project file, or there were fields that are missing that I need.
+
+Here's the details:
+> - Field '/upforgrabs/link' expects a URL but instead found 'not-a-url'. Please check and update this value.

--- a/test/fixtures/pull_request/three-files-one-error/_data/projects/first.yml
+++ b/test/fixtures/pull_request/three-files-one-error/_data/projects/first.yml
@@ -1,0 +1,12 @@
+---
+name: Up-For-Grabs.net
+desc: This site!
+site: https://github.com/owner/first
+tags:
+- oss
+- web
+- jekyll
+- javascript
+upforgrabs:
+  name: up-for-grabs
+  link: https://github.com/owner/first/labels/up-for-grabs

--- a/test/fixtures/pull_request/three-files-one-error/_data/projects/second.yml
+++ b/test/fixtures/pull_request/three-files-one-error/_data/projects/second.yml
@@ -1,0 +1,12 @@
+---
+name: Up-For-Grabs.net
+desc: This site!
+site: https://github.com/owner/second
+tags:
+- oss
+- web
+- jekyll
+- javascript
+upforgrabs:
+  name: up-for-grabs
+  link: https://github.com/owner/second/labels/up-for-grabs

--- a/test/fixtures/pull_request/three-files-one-error/_data/projects/third.yml
+++ b/test/fixtures/pull_request/three-files-one-error/_data/projects/third.yml
@@ -1,7 +1,7 @@
 ---
-name: Up-For-Grabs.net
-desc: This site!
-site: https://github.com/owner/third
+name: A Project
+desc: It does things!
+site: https://somesite.com
 tags:
 - oss
 - web
@@ -9,4 +9,4 @@ tags:
 - javascript
 upforgrabs:
   name: up-for-grabs
-  link: https://github.com/owner/third/labels/up-for-grabs
+  link: not-a-url

--- a/test/fixtures/pull_request/three-files-one-error/_data/projects/third.yml
+++ b/test/fixtures/pull_request/three-files-one-error/_data/projects/third.yml
@@ -1,0 +1,12 @@
+---
+name: Up-For-Grabs.net
+desc: This site!
+site: https://github.com/owner/third
+tags:
+- oss
+- web
+- jekyll
+- javascript
+upforgrabs:
+  name: up-for-grabs
+  link: https://github.com/owner/third/labels/up-for-grabs

--- a/test/fixtures/pull_request/three-valid-files-result.md
+++ b/test/fixtures/pull_request/three-valid-files-result.md
@@ -1,0 +1,9 @@
+<!-- PULL REQUEST ANALYZER GITHUB ACTION -->
+
+:wave: I'm a robot checking the state of this pull request to save the human reveiwers time. I noticed this PR added or modififed the data files under `_data/projects/` so I had a look at what's changed.
+
+As you make changes to this pull request, I'll re-run these checks.
+
+#### **3** projects without issues :white_check_mark:
+
+Everything should be good to merge!

--- a/test/fixtures/pull_request/three-valid-files/_data/projects/first.yml
+++ b/test/fixtures/pull_request/three-valid-files/_data/projects/first.yml
@@ -1,0 +1,12 @@
+---
+name: The Project
+desc: A Description Goes Here
+site: https://the-project.com
+tags:
+- oss
+- web
+- jekyll
+- javascript
+upforgrabs:
+  name: up-for-grabs
+  link: https://the-project.com/tasks/up-for-grabs

--- a/test/fixtures/pull_request/three-valid-files/_data/projects/second.yml
+++ b/test/fixtures/pull_request/three-valid-files/_data/projects/second.yml
@@ -1,0 +1,12 @@
+---
+name: Another Project
+desc: It also does things
+site: https://project-web-site.com/
+tags:
+- oss
+- web
+- jekyll
+- javascript
+upforgrabs:
+  name: help-wanted
+  link: https://project-web-site.com/help-wanted

--- a/test/fixtures/pull_request/three-valid-files/_data/projects/third.yml
+++ b/test/fixtures/pull_request/three-valid-files/_data/projects/third.yml
@@ -1,0 +1,12 @@
+---
+name: A Project
+desc: It does things!
+site: https://somesite.com
+tags:
+- oss
+- web
+- jekyll
+- javascript
+upforgrabs:
+  name: up-for-grabs
+  link: https://somesite.com/project/tasks

--- a/test/fixtures/pull_request/two-valid-files-result.md
+++ b/test/fixtures/pull_request/two-valid-files-result.md
@@ -1,0 +1,11 @@
+<!-- PULL REQUEST ANALYZER GITHUB ACTION -->
+
+:wave: I'm a robot checking the state of this pull request to save the human reveiwers time. I noticed this PR added or modififed the data files under `_data/projects/` so I had a look at what's changed.
+
+As you make changes to this pull request, I'll re-run these checks.
+
+#### `_data/projects/first.yml` :white_check_mark:
+No problems found, everything should be good to merge!
+
+#### `_data/projects/second.yml` :white_check_mark:
+No problems found, everything should be good to merge!

--- a/test/fixtures/pull_request/two-valid-files/_data/projects/first.yml
+++ b/test/fixtures/pull_request/two-valid-files/_data/projects/first.yml
@@ -1,0 +1,12 @@
+---
+name: Up-For-Grabs.net
+desc: This site!
+site: https://github.com/owner/first
+tags:
+- oss
+- web
+- jekyll
+- javascript
+upforgrabs:
+  name: up-for-grabs
+  link: https://github.com/owner/first/labels/up-for-grabs

--- a/test/fixtures/pull_request/two-valid-files/_data/projects/second.yml
+++ b/test/fixtures/pull_request/two-valid-files/_data/projects/second.yml
@@ -1,0 +1,12 @@
+---
+name: Up-For-Grabs.net
+desc: This site!
+site: https://github.com/owner/second
+tags:
+- oss
+- web
+- jekyll
+- javascript
+upforgrabs:
+  name: up-for-grabs
+  link: https://github.com/owner/second/labels/up-for-grabs

--- a/test/fixtures/pull_request/wrong-extension-result.md
+++ b/test/fixtures/pull_request/wrong-extension-result.md
@@ -1,0 +1,11 @@
+<!-- PULL REQUEST ANALYZER GITHUB ACTION -->
+
+:wave: I'm a robot checking the state of this pull request to save the human reveiwers time. I noticed this PR added or modififed the data files under `_data/projects/` so I had a look at what's changed.
+
+As you make changes to this pull request, I'll re-run these checks.
+
+#### Unexpected files found in project directory
+
+ - `_data/projects/project.yaml`
+
+All files under `_data/projects/` must end with `.yml` to be listed on the site

--- a/test/fixtures/pull_request/wrong-extension/_data/projects/project.yaml
+++ b/test/fixtures/pull_request/wrong-extension/_data/projects/project.yaml
@@ -1,0 +1,12 @@
+---
+name: Up-For-Grabs.net
+desc: This site!
+site: https://github.com/up-for-grabs/up-for-grabs.net
+tags:
+- oss
+- web
+- jekyll
+- javascript
+upforgrabs:
+  name: up-for-grabs
+  link: https://github.com/up-for-grabs/up-for-grabs.net/labels/up-for-grabs

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,4 +6,6 @@ SimpleCov.start do
 end
 
 require 'minitest/autorun'
+require 'mocha/minitest'
+
 require './lib/up_for_grabs_tooling'

--- a/test/validators/pull_request_test.rb
+++ b/test/validators/pull_request_test.rb
@@ -95,6 +95,26 @@ class PullRequestValidatorTests < Minitest::Test
     assert_markdown 'one-file-no-preamble', message
   end
 
+  def test_one_file_with_label_error
+    dir = get_test_directory('one-file-label-error')
+    files = get_files_in_directory('one-file-label-error')
+
+    # stub these calls that depend on the GitHub API
+    GitHubRepositoryActiveCheck
+      .expects(:run)
+      .returns({})
+
+    GitHubRepositoryLabelActiveCheck
+      .expects(:run)
+      .returns({
+                 url: 'https://github.com/owner/redirected-repo/labels/label'
+               })
+
+    message = PullRequestValidator.validate(dir, files)
+
+    assert_markdown 'one-file-label-error', message
+  end
+
   def test_two_files_with_no_problems_lists_both_files
     dir = get_test_directory('two-valid-files')
     files = get_files_in_directory('two-valid-files')

--- a/test/validators/pull_request_test.rb
+++ b/test/validators/pull_request_test.rb
@@ -8,13 +8,19 @@ class PullRequestValidatorTests < Minitest::Test
     files = get_files_in_directory('one-file')
 
     # stub these calls that depend on the GitHub API
-    PullRequestValidator
-      .expects(:repository_check)
-      .returns(nil)
+    repository_result = { }
 
-    PullRequestValidator
-      .expects(:label_check)
-      .returns(nil)
+    GitHubRepositoryActiveCheck
+      .expects(:run)
+      .returns(repository_result)
+
+    label_result = {
+      url: "https://github.com/up-for-grabs/up-for-grabs.net/labels/up-for-grabs"
+    }
+
+    GitHubRepositoryLabelActiveCheck
+      .expects(:run)
+      .returns(label_result)
 
     message = PullRequestValidator.validate(dir, files)
 
@@ -46,6 +52,22 @@ class PullRequestValidatorTests < Minitest::Test
     message = PullRequestValidator.validate(dir, files)
 
     assert_markdown 'schema-validation', message
+  end
+
+  def test_one_file_warn_when_github_project_archived
+    dir = get_test_directory('github-repository-archived')
+    files = get_files_in_directory('github-repository-archived')
+
+    # stub these calls that depend on the GitHub API
+    archived = { reason: 'archived' }
+
+    GitHubRepositoryActiveCheck
+      .expects(:run)
+      .returns(archived)
+
+    message = PullRequestValidator.validate(dir, files)
+
+    assert_markdown 'github-repository-archived', message
   end
 
   def test_one_file_warn_when_tags_need_rename

--- a/test/validators/pull_request_test.rb
+++ b/test/validators/pull_request_test.rb
@@ -66,6 +66,6 @@ class PullRequestValidatorTests < Minitest::Test
   def get_files_in_directory(name)
     parent = File.dirname(__dir__)
     root = "#{parent}/fixtures/pull_request/#{name}"
-    Dir.chdir(root) { Dir.glob("**/*").select { |path| File.file?(path) } }
+    Dir.chdir(root) { Dir.glob('**/*').select { |path| File.file?(path) } }
   end
 end

--- a/test/validators/pull_request_test.rb
+++ b/test/validators/pull_request_test.rb
@@ -141,7 +141,39 @@ class PullRequestValidatorTests < Minitest::Test
   end
 
   def test_one_file_with_error_out_of_three_only_lists_problem_file
-    skip 'TODO'
+    dir = get_test_directory('three-files-one-error')
+    files = get_files_in_directory('three-files-one-error')
+
+    first = files[0]
+    second = files[1]
+
+    GitHubRepositoryActiveCheck
+      .expects(:run)
+      .with { |project| project.relative_path == first }
+      .returns({})
+
+    GitHubRepositoryLabelActiveCheck
+      .expects(:run)
+      .with { |project| project.relative_path == first }
+      .returns({
+                 url: 'https://github.com/owner/first/labels/up-for-grabs'
+               })
+
+    GitHubRepositoryActiveCheck
+      .expects(:run)
+      .with { |project| project.relative_path == second }
+      .returns({})
+
+    GitHubRepositoryLabelActiveCheck
+      .expects(:run)
+      .with { |project| project.relative_path == second }
+      .returns({
+                 url: 'https://github.com/owner/second/labels/up-for-grabs'
+               })
+
+    message = PullRequestValidator.validate(dir, files)
+
+    assert_markdown 'three-files-one-error', message
   end
 
   def test_twenty_files_without_error_lists_summary

--- a/test/validators/pull_request_test.rb
+++ b/test/validators/pull_request_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+class PullRequestValidatorTests < Minitest::Test
+  def test_one_file_is_good_to_merge
+    dir = get_test_directory('one-file')
+    files = get_files_in_directory('one-file')
+
+    # stub these calls that depend on the GitHub API
+    PullRequestValidator
+      .expects(:repository_check)
+      .returns(nil)
+
+    PullRequestValidator
+      .expects(:label_check)
+      .returns(nil)
+
+    message = PullRequestValidator.validate(dir, files)
+
+    assert_match '#### `_data/projects/project.yml` :white_check_mark: ', message
+    assert_match 'No problems found, everything should be good to merge!', message
+  end
+
+  # def test_one_file_warn_when_wrong_extension
+  #   refute true
+  # end
+
+  # def test_one_file_warn_when_schema_validation_failed
+  #   refute true
+  # end
+
+  # def test_one_file_warn_when_tags_need_rename
+  #   refute true
+  # end
+
+  # def test_one_file_changed_with_no_previous_message_includes_preamble
+  #   refute true
+  # end
+
+  # def test_one_file_changed_with_previous_message_omits_preamble
+  #   refute true
+  # end
+
+  # def test_two_files_with_no_problems_lists_both_files
+  #   refute true
+  # end
+
+  # def test_three_files_with_no_problems_lists_summary
+  #   refute true
+  # end
+
+  # def test_one_file_with_error_out_of_three_only_lists_problem_file
+  #   refute true
+  # end
+
+  # def test_twenty_files_without_error_lists_summary
+  #   refute true
+  # end
+
+  def get_test_directory(name)
+    parent = File.dirname(__dir__)
+    Pathname.new("#{parent}/fixtures/pull_request/#{name}")
+  end
+
+  def get_files_in_directory(name)
+    parent = File.dirname(__dir__)
+    root = "#{parent}/fixtures/pull_request/#{name}"
+    Dir.chdir(root) { Dir.glob("**/*").select { |path| File.file?(path) } }
+  end
+end

--- a/test/validators/pull_request_test.rb
+++ b/test/validators/pull_request_test.rb
@@ -8,19 +8,15 @@ class PullRequestValidatorTests < Minitest::Test
     files = get_files_in_directory('one-file')
 
     # stub these calls that depend on the GitHub API
-    repository_result = { }
-
     GitHubRepositoryActiveCheck
       .expects(:run)
-      .returns(repository_result)
-
-    label_result = {
-      url: "https://github.com/up-for-grabs/up-for-grabs.net/labels/up-for-grabs"
-    }
+      .returns({})
 
     GitHubRepositoryLabelActiveCheck
       .expects(:run)
-      .returns(label_result)
+      .returns({
+                 url: 'https://github.com/up-for-grabs/up-for-grabs.net/labels/up-for-grabs'
+               })
 
     message = PullRequestValidator.validate(dir, files)
 
@@ -54,6 +50,15 @@ class PullRequestValidatorTests < Minitest::Test
     assert_markdown 'schema-validation', message
   end
 
+  def test_one_file_warn_when_tags_need_rename
+    dir = get_test_directory('tags-validation')
+    files = get_files_in_directory('tags-validation')
+
+    message = PullRequestValidator.validate(dir, files)
+
+    assert_markdown 'tags-validation', message
+  end
+
   def test_one_file_warn_when_github_project_archived
     dir = get_test_directory('github-repository-archived')
     files = get_files_in_directory('github-repository-archived')
@@ -70,32 +75,28 @@ class PullRequestValidatorTests < Minitest::Test
     assert_markdown 'github-repository-archived', message
   end
 
-  def test_one_file_warn_when_tags_need_rename
-    skip "TODO"
-  end
-
   def test_one_file_changed_with_no_previous_message_includes_preamble
-    skip "TODO"
+    skip 'TODO'
   end
 
   def test_one_file_changed_with_previous_message_omits_preamble
-    skip "TODO"
+    skip 'TODO'
   end
 
   def test_two_files_with_no_problems_lists_both_files
-    skip "TODO"
+    skip 'TODO'
   end
 
   def test_three_files_with_no_problems_lists_summary
-    skip "TODO"
+    skip 'TODO'
   end
 
   def test_one_file_with_error_out_of_three_only_lists_problem_file
-    skip "TODO"
+    skip 'TODO'
   end
 
   def test_twenty_files_without_error_lists_summary
-    skip "TODO"
+    skip 'TODO'
   end
 
   def assert_markdown(name, output)

--- a/test/validators/pull_request_test.rb
+++ b/test/validators/pull_request_test.rb
@@ -44,9 +44,15 @@ class PullRequestValidatorTests < Minitest::Test
     assert_match 'All files under `_data/projects/` must end with `.yml` to be listed on the site', message
   end
 
-  # def test_one_file_warn_when_schema_validation_failed
-  #   refute true
-  # end
+  def test_one_file_warn_when_schema_validation_failed
+    dir = get_test_directory('schema-validation')
+    files = get_files_in_directory('schema-validation')
+
+    message = PullRequestValidator.validate(dir, files)
+
+    assert_match '#### `_data/projects/error_site_link_url.yml` :x:', message
+    assert_match ' Field \'/site\' expects a URL but instead found \'foo\'. Please check and update this value.', message
+  end
 
   # def test_one_file_warn_when_tags_need_rename
   #   refute true

--- a/test/validators/pull_request_test.rb
+++ b/test/validators/pull_request_test.rb
@@ -22,9 +22,27 @@ class PullRequestValidatorTests < Minitest::Test
     assert_match 'No problems found, everything should be good to merge!', message
   end
 
-  # def test_one_file_warn_when_wrong_extension
-  #   refute true
-  # end
+  def test_one_file_warn_when_wrong_extension
+    dir = get_test_directory('wrong-extension')
+    files = get_files_in_directory('wrong-extension')
+
+    message = PullRequestValidator.validate(dir, files)
+
+    assert_match '#### Unexpected files found in project directory', message
+    assert_match ' - `_data/projects/project.yaml`', message
+    assert_match 'All files under `_data/projects/` must end with `.yml` to be listed on the site', message
+  end
+
+  def test_one_file_warn_when_no_extension
+    dir = get_test_directory('missing-extension')
+    files = get_files_in_directory('missing-extension')
+
+    message = PullRequestValidator.validate(dir, files)
+
+    assert_match '#### Unexpected files found in project directory', message
+    assert_match ' - `_data/projects/project`', message
+    assert_match 'All files under `_data/projects/` must end with `.yml` to be listed on the site', message
+  end
 
   # def test_one_file_warn_when_schema_validation_failed
   #   refute true

--- a/test/validators/pull_request_test.rb
+++ b/test/validators/pull_request_test.rb
@@ -132,7 +132,12 @@ class PullRequestValidatorTests < Minitest::Test
   end
 
   def test_three_files_with_no_problems_lists_summary
-    skip 'TODO'
+    dir = get_test_directory('three-valid-files')
+    files = get_files_in_directory('three-valid-files')
+
+    message = PullRequestValidator.validate(dir, files)
+
+    assert_markdown 'three-valid-files', message
   end
 
   def test_one_file_with_error_out_of_three_only_lists_problem_file

--- a/test/validators/pull_request_test.rb
+++ b/test/validators/pull_request_test.rb
@@ -75,12 +75,24 @@ class PullRequestValidatorTests < Minitest::Test
     assert_markdown 'github-repository-archived', message
   end
 
-  def test_one_file_changed_with_no_previous_message_includes_preamble
-    skip 'TODO'
-  end
-
   def test_one_file_changed_with_previous_message_omits_preamble
-    skip 'TODO'
+    dir = get_test_directory('one-file')
+    files = get_files_in_directory('one-file')
+
+    # stub these calls that depend on the GitHub API
+    GitHubRepositoryActiveCheck
+      .expects(:run)
+      .returns({})
+
+    GitHubRepositoryLabelActiveCheck
+      .expects(:run)
+      .returns({
+                 url: 'https://github.com/up-for-grabs/up-for-grabs.net/labels/up-for-grabs'
+               })
+
+    message = PullRequestValidator.validate(dir, files, initial_message: false)
+
+    assert_markdown 'one-file-no-preamble', message
   end
 
   def test_two_files_with_no_problems_lists_both_files

--- a/test/validators/pull_request_test.rb
+++ b/test/validators/pull_request_test.rb
@@ -18,7 +18,7 @@ class PullRequestValidatorTests < Minitest::Test
                  url: 'https://github.com/up-for-grabs/up-for-grabs.net/labels/up-for-grabs'
                })
 
-    message = PullRequestValidator.validate(dir, files)
+    message = PullRequestValidator.generate_comment(dir, files)
 
     assert_markdown 'one-file', message
   end
@@ -27,7 +27,7 @@ class PullRequestValidatorTests < Minitest::Test
     dir = get_test_directory('wrong-extension')
     files = get_files_in_directory('wrong-extension')
 
-    message = PullRequestValidator.validate(dir, files)
+    message = PullRequestValidator.generate_comment(dir, files)
 
     assert_markdown 'wrong-extension', message
   end
@@ -36,7 +36,7 @@ class PullRequestValidatorTests < Minitest::Test
     dir = get_test_directory('missing-extension')
     files = get_files_in_directory('missing-extension')
 
-    message = PullRequestValidator.validate(dir, files)
+    message = PullRequestValidator.generate_comment(dir, files)
 
     assert_markdown 'missing-extension', message
   end
@@ -45,7 +45,7 @@ class PullRequestValidatorTests < Minitest::Test
     dir = get_test_directory('schema-validation')
     files = get_files_in_directory('schema-validation')
 
-    message = PullRequestValidator.validate(dir, files)
+    message = PullRequestValidator.generate_comment(dir, files)
 
     assert_markdown 'schema-validation', message
   end
@@ -54,7 +54,7 @@ class PullRequestValidatorTests < Minitest::Test
     dir = get_test_directory('tags-validation')
     files = get_files_in_directory('tags-validation')
 
-    message = PullRequestValidator.validate(dir, files)
+    message = PullRequestValidator.generate_comment(dir, files)
 
     assert_markdown 'tags-validation', message
   end
@@ -70,7 +70,7 @@ class PullRequestValidatorTests < Minitest::Test
       .expects(:run)
       .returns(archived)
 
-    message = PullRequestValidator.validate(dir, files)
+    message = PullRequestValidator.generate_comment(dir, files)
 
     assert_markdown 'github-repository-archived', message
   end
@@ -90,7 +90,7 @@ class PullRequestValidatorTests < Minitest::Test
                  url: 'https://github.com/up-for-grabs/up-for-grabs.net/labels/up-for-grabs'
                })
 
-    message = PullRequestValidator.validate(dir, files, initial_message: false)
+    message = PullRequestValidator.generate_comment(dir, files, initial_message: false)
 
     assert_markdown 'one-file-no-preamble', message
   end
@@ -110,7 +110,7 @@ class PullRequestValidatorTests < Minitest::Test
                  url: 'https://github.com/owner/redirected-repo/labels/label'
                })
 
-    message = PullRequestValidator.validate(dir, files)
+    message = PullRequestValidator.generate_comment(dir, files)
 
     assert_markdown 'one-file-label-error', message
   end
@@ -146,7 +146,7 @@ class PullRequestValidatorTests < Minitest::Test
                  url: 'https://github.com/owner/second/labels/up-for-grabs'
                })
 
-    message = PullRequestValidator.validate(dir, files)
+    message = PullRequestValidator.generate_comment(dir, files)
 
     assert_markdown 'two-valid-files', message
   end
@@ -155,7 +155,7 @@ class PullRequestValidatorTests < Minitest::Test
     dir = get_test_directory('three-valid-files')
     files = get_files_in_directory('three-valid-files')
 
-    message = PullRequestValidator.validate(dir, files)
+    message = PullRequestValidator.generate_comment(dir, files)
 
     assert_markdown 'three-valid-files', message
   end
@@ -191,7 +191,7 @@ class PullRequestValidatorTests < Minitest::Test
                  url: 'https://github.com/owner/second/labels/up-for-grabs'
                })
 
-    message = PullRequestValidator.validate(dir, files)
+    message = PullRequestValidator.generate_comment(dir, files)
 
     assert_markdown 'three-files-one-error', message
   end

--- a/test/validators/pull_request_test.rb
+++ b/test/validators/pull_request_test.rb
@@ -18,8 +18,7 @@ class PullRequestValidatorTests < Minitest::Test
 
     message = PullRequestValidator.validate(dir, files)
 
-    assert_match '#### `_data/projects/project.yml` :white_check_mark: ', message
-    assert_match 'No problems found, everything should be good to merge!', message
+    assert_markdown 'one-file', message
   end
 
   def test_one_file_warn_when_wrong_extension
@@ -28,9 +27,7 @@ class PullRequestValidatorTests < Minitest::Test
 
     message = PullRequestValidator.validate(dir, files)
 
-    assert_match '#### Unexpected files found in project directory', message
-    assert_match ' - `_data/projects/project.yaml`', message
-    assert_match 'All files under `_data/projects/` must end with `.yml` to be listed on the site', message
+    assert_markdown 'wrong-extension', message
   end
 
   def test_one_file_warn_when_no_extension
@@ -39,9 +36,7 @@ class PullRequestValidatorTests < Minitest::Test
 
     message = PullRequestValidator.validate(dir, files)
 
-    assert_match '#### Unexpected files found in project directory', message
-    assert_match ' - `_data/projects/project`', message
-    assert_match 'All files under `_data/projects/` must end with `.yml` to be listed on the site', message
+    assert_markdown 'missing-extension', message
   end
 
   def test_one_file_warn_when_schema_validation_failed
@@ -50,37 +45,42 @@ class PullRequestValidatorTests < Minitest::Test
 
     message = PullRequestValidator.validate(dir, files)
 
-    assert_match '#### `_data/projects/error_site_link_url.yml` :x:', message
-    assert_match ' Field \'/site\' expects a URL but instead found \'foo\'. Please check and update this value.', message
+    assert_markdown 'schema-validation', message
   end
 
-  # def test_one_file_warn_when_tags_need_rename
-  #   refute true
-  # end
+  def test_one_file_warn_when_tags_need_rename
+    skip "TODO"
+  end
 
-  # def test_one_file_changed_with_no_previous_message_includes_preamble
-  #   refute true
-  # end
+  def test_one_file_changed_with_no_previous_message_includes_preamble
+    skip "TODO"
+  end
 
-  # def test_one_file_changed_with_previous_message_omits_preamble
-  #   refute true
-  # end
+  def test_one_file_changed_with_previous_message_omits_preamble
+    skip "TODO"
+  end
 
-  # def test_two_files_with_no_problems_lists_both_files
-  #   refute true
-  # end
+  def test_two_files_with_no_problems_lists_both_files
+    skip "TODO"
+  end
 
-  # def test_three_files_with_no_problems_lists_summary
-  #   refute true
-  # end
+  def test_three_files_with_no_problems_lists_summary
+    skip "TODO"
+  end
 
-  # def test_one_file_with_error_out_of_three_only_lists_problem_file
-  #   refute true
-  # end
+  def test_one_file_with_error_out_of_three_only_lists_problem_file
+    skip "TODO"
+  end
 
-  # def test_twenty_files_without_error_lists_summary
-  #   refute true
-  # end
+  def test_twenty_files_without_error_lists_summary
+    skip "TODO"
+  end
+
+  def assert_markdown(name, output)
+    parent = File.dirname(__dir__)
+    expected = File.read("#{parent}/fixtures/pull_request/#{name}-result.md")
+    assert_equal output.chomp, expected.chomp
+  end
 
   def get_test_directory(name)
     parent = File.dirname(__dir__)

--- a/test/validators/pull_request_test.rb
+++ b/test/validators/pull_request_test.rb
@@ -176,10 +176,6 @@ class PullRequestValidatorTests < Minitest::Test
     assert_markdown 'three-files-one-error', message
   end
 
-  def test_twenty_files_without_error_lists_summary
-    skip 'TODO'
-  end
-
   def assert_markdown(name, output)
     parent = File.dirname(__dir__)
     expected = File.read("#{parent}/fixtures/pull_request/#{name}-result.md")

--- a/test/validators/tags_test.rb
+++ b/test/validators/tags_test.rb
@@ -14,7 +14,7 @@ class TagsValidatorTests < Minitest::Test
 
     result = TagsValidator.validate(project)
 
-    assert_equal result[0], "Rename tag 'js' to be'javascript'"
+    assert_equal result[0], "Rename tag 'js' to be 'javascript'"
   end
 
   def test_tags_as_string_error


### PR DESCRIPTION
This code is currently working fine inside `shiftkey/webhooks`, but I'd like to extract it and get it under test, so that we can make changes in the future and know we're not regressing things.

The API I'm aiming for:

```ruby
message = PullRequestValidator.generate_comment(dir, files)
```

`dir` is the `Pathname` that points to the root of the repository, and `files` is the array of relative paths that represent changed project files. What gets generated inside is markdown text that becomes the comment body.

 - [x] extract code, get a test passing
 - [x] expand test suite to cover surface area and needed changes
 - [x] cleanup code to make it more readable