### PR TITLE
handle mis-typed URL and explicitly warn about problem

### DIFF
--- a/test/fixtures/pull_request/one-file-label-url-error-result.md
+++ b/test/fixtures/pull_request/one-file-label-url-error-result.md
@@ -1,0 +1,8 @@
+<!-- PULL REQUEST ANALYZER GITHUB ACTION -->
+
+:wave: I'm a robot checking the state of this pull request to save the human reveiwers time. I noticed this PR added or modififed the data files under `_data/projects/` so I had a look at what's changed.
+
+As you make changes to this pull request, I'll re-run these checks.
+
+#### `_data/projects/project.yml` :x:
+The `upforgrabs.url` value hhttps://github.com/owner/repo/labels/label is not a valid URL - please check and update the value.

--- a/test/fixtures/pull_request/one-file-label-url-error/_data/projects/project.yml
+++ b/test/fixtures/pull_request/one-file-label-url-error/_data/projects/project.yml
@@ -1,0 +1,12 @@
+---
+name: Some Project
+desc: This is very much a project
+site: https://github.com/owner/repo
+tags:
+- tag
+- tag2
+- tag3
+- tag4
+upforgrabs:
+  name: label
+  link: hhttps://github.com/owner/repo/labels/label

--- a/test/validators/pull_request_test.rb
+++ b/test/validators/pull_request_test.rb
@@ -206,6 +206,15 @@ class PullRequestValidatorTests < Minitest::Test
     assert_markdown 'three-files-one-error', message
   end
 
+  def test_one_file_with_invalid_url_reports_error
+    dir = get_test_directory('one-file-label-url-error')
+    files = get_files_in_directory('one-file-label-url-error')
+
+    message = PullRequestValidator.generate_comment(dir, files)
+
+    assert_markdown 'one-file-label-url-error', message
+  end
+
   def assert_markdown(name, output)
     parent = File.dirname(__dir__)
     expected = File.read("#{parent}/fixtures/pull_request/#{name}-result.md")


### PR DESCRIPTION
Closes https://github.com/shiftkey/webhooks/issues/65

For some reason our schema validation doesn't catch this issue, and inside `Project` we just give up if we can't parse the URL to see that it's a GitHub project:

https://github.com/up-for-grabs/tooling/blob/d659be6f45796395f785375ae8527823c12da415/lib/models/project.rb#L47-L58