### PR TITLE
fix error where rate-limiting causes job to crash

### DIFF
--- a/lib/validators/pull_request.rb
+++ b/lib/validators/pull_request.rb
@@ -119,8 +119,8 @@ class PullRequestValidator
     result = GitHubRepositoryActiveCheck.run(project)
 
     if result[:rate_limited]
-      logger.info 'This script is currently rate-limited by the GitHub API'
-      logger.info 'Marking as inconclusive to indicate that no further work will be done here'
+      # logger.info 'This script is currently rate-limited by the GitHub API'
+      # logger.info 'Marking as inconclusive to indicate that no further work will be done here'
       return nil
     end
 
@@ -147,8 +147,8 @@ class PullRequestValidator
     result = GitHubRepositoryLabelActiveCheck.run(project)
 
     if result[:rate_limited]
-      logger.info 'This script is currently rate-limited by the GitHub API'
-      logger.info 'Marking as inconclusive to indicate that no further work will be done here'
+      # logger.info 'This script is currently rate-limited by the GitHub API'
+      # logger.info 'Marking as inconclusive to indicate that no further work will be done here'
       return nil
     end
 


### PR DESCRIPTION
Spotted in production while trying to resolve https://github.com/up-for-grabs/up-for-grabs.net/issues/3382

```
ERROR -- : [ActiveJob] [UpForGrabsPullRequestProjectAnalyzerJob] [cb53d6a8-9db0-463c-9030-b068e3e02f19] Error performing UpForGrabsPullRequestProjectAnalyzerJob (Job ID: cb53d6a8-9db0-463c-9030-b068e3e02f19) from Async(default) in 65471.58ms: NameError (undefined local variable or method `logger' for PullRequestValidator:Class):
/app/vendor/ruby/3.0.0/bundler/gems/tooling-9068ee06789d/lib/validators/pull_request.rb:122:in `repository_check'
/app/vendor/ruby/3.0.0/bundler/gems/tooling-9068ee06789d/lib/validators/pull_request.rb:105:in `review_project'
/app/vendor/ruby/3.0.0/bundler/gems/tooling-9068ee06789d/lib/validators/pull_request.rb:41:in `block in generate_comment'
...
```