### PR TITLE
warn if any .yaml files have been added to the projects directory

### DIFF
--- a/lib/validators/pull_request.rb
+++ b/lib/validators/pull_request.rb
@@ -16,7 +16,7 @@ class PullRequestValidator
 
   UPDATE_HEADER = 'Checking the latest changes to the pull request...'
 
-  ALLOWED_EXTENSIONS = ['.yml', '.yaml'].freeze
+  ALLOWED_EXTENSIONS = ['.yml'].freeze
 
   def self.generate_comment(dir, files, initial_message: true)
     projects = files.map do |f|
@@ -36,7 +36,7 @@ class PullRequestValidator
       projects_without_valid_extensions.each do |p|
         messages << " - `#{p.relative_path}`"
       end
-      messages << 'All files under `_data/projects/` must end with `.yml` or `.yaml` to be listed on the site'
+      messages << 'All files under `_data/projects/` must end with `.yml` to be listed on the site'
     elsif projects.count > 2
       results = projects.map { |p| review_project(p) }
       valid_projects, projects_with_errors = results.partition { |r| r[:kind] == 'valid' }

--- a/test/fixtures/pull_request/alternate-yaml-extension-result.md
+++ b/test/fixtures/pull_request/alternate-yaml-extension-result.md
@@ -4,5 +4,8 @@
 
 As you make changes to this pull request, I'll re-run these checks.
 
-#### `_data/projects/project.yaml` :white_check_mark:
-No problems found, everything should be good to merge!
+#### Unexpected files found in project directory
+
+ - `_data/projects/project.yaml`
+
+All files under `_data/projects/` must end with `.yml` to be listed on the site

--- a/test/fixtures/pull_request/missing-extension-result.md
+++ b/test/fixtures/pull_request/missing-extension-result.md
@@ -8,4 +8,4 @@ As you make changes to this pull request, I'll re-run these checks.
 
  - `_data/projects/project`
 
-All files under `_data/projects/` must end with `.yml` or `.yaml` to be listed on the site
+All files under `_data/projects/` must end with `.yml` to be listed on the site

--- a/test/fixtures/pull_request/wrong-extension-result.md
+++ b/test/fixtures/pull_request/wrong-extension-result.md
@@ -8,4 +8,4 @@ As you make changes to this pull request, I'll re-run these checks.
 
  - `_data/projects/project.json`
 
-All files under `_data/projects/` must end with `.yml` or `.yaml` to be listed on the site
+All files under `_data/projects/` must end with `.yml` to be listed on the site

--- a/test/validators/pull_request_test.rb
+++ b/test/validators/pull_request_test.rb
@@ -27,17 +27,6 @@ class PullRequestValidatorTests < Minitest::Test
     dir = get_test_directory('alternate-yaml-extension')
     files = get_files_in_directory('alternate-yaml-extension')
 
-    # stub these calls that depend on the GitHub API
-    GitHubRepositoryActiveCheck
-      .expects(:run)
-      .returns({})
-
-    GitHubRepositoryLabelActiveCheck
-      .expects(:run)
-      .returns({
-                 url: 'https://github.com/up-for-grabs/up-for-grabs.net/labels/up-for-grabs'
-               })
-
     message = PullRequestValidator.generate_comment(dir, files)
 
     assert_markdown 'alternate-yaml-extension', message


### PR DESCRIPTION
Proactive warnings for ignored `.yaml` files even though these are ingested by Jekyll

See https://github.com/up-for-grabs/up-for-grabs.net/issues/3417 for more context