### PR TITLE
lock graphql to previous release while i investigate breaking changes

### DIFF
--- a/up_for_grabs_tooling.gemspec
+++ b/up_for_grabs_tooling.gemspec
@@ -15,5 +15,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'safe_yaml', '~> 1.0'
   s.add_runtime_dependency 'octokit', '>= 5.6', '< 8.0'
   s.add_runtime_dependency 'graphql-client', '~> 0.18'
+  s.add_runtime_dependency 'graphql', '~> 2.0.27'
   s.add_runtime_dependency 'json_schemer', '>= 0.2', '< 3.0'
 end


### PR DESCRIPTION
While I check in on these links to see what's changed with `2.1.0` 

 - https://github.com/rmosolgo/graphql-ruby/pull/4577#issuecomment-1700565699
 - https://github.com/github/graphql-client/issues/310

Let's roll this back to the previous release which seems to work